### PR TITLE
TTWEBTAKEN-122: Add support for PHP 8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: false
 language: php
 
 php:
-    - 7.3
     - 7.4
+    - 8.0
+    - 8.1
 
 before_install:
     # Update & configure composer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All Notable changes to `digipolisgent/flanders-basicregisters` package.
 
+## [Unreleased]
+
+### Added
+
+* Add support for PHP 8.x.
+
+### Updated
+
+* Update digipolisgent/api-client to 3.x.
+* Update digipolisgent/value to 3.x.
+
+### Changed
+
+* Change minimal PHP version to PHP 7.4.
+
 ## [1.0.0]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     ],
     "homepage": "https://github.com/digipolisgent/php_package_dg-flanders-basicregisters",
     "require": {
-        "php": "^7.3",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "digipolisgent/api-client": "^1.1 || ^2.0",
-        "digipolisgent/value": "^1.1 || ^2.0"
+        "digipolisgent/api-client": "^3.0",
+        "digipolisgent/value": "^3.0"
     },
     "require-dev": {
         "district09/qa-php": "^1.0.1"


### PR DESCRIPTION
- Add support for PHP 8.x.
- Update digipolisgent/api-client to 3.x.
- Update digipolisgent/value to 3.x.
